### PR TITLE
Terraform hotfix

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -22,6 +22,7 @@ resource "yandex_vpc_subnet" "develop_b" {
 
 module "marketing-vm" {
   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  tag = var.tag
   env_name       = var.each_vm.marketing.name
   network_id     = module.vpc.vpc_network_id
   subnet_zones   = [var.default_zone]
@@ -43,6 +44,7 @@ module "marketing-vm" {
 
 module "analytics-vm" {
   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  var = var.tag
   env_name       = var.each_vm.analytics.name
   network_id     = module.vpc.vpc_network_id
   subnet_zones   = [var.default_zone]
@@ -64,6 +66,7 @@ module "analytics-vm" {
 
 module "vpc" {
   source             = "./vpc"
+  var = var.tag
   vpc_name           = var.vpc_name
   default_zone       = var.default_zone
   default_cidr       = var.default_cidr

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -5,6 +5,22 @@ terraform {
     }
   }
   required_version = "~>1.8.4"
+
+  backend "s3" {
+    endpoints = {
+      s3 = "https://storage.yandexcloud.net"
+    }
+    bucket = "tfstate-123"
+    region = "ru-central1"
+    key    = "terraform.tfstate"
+
+    skip_region_validation      = true
+    skip_credentials_validation = true
+    skip_requesting_account_id  = true # Необходимая опция Terraform для версии 1.6.1 и старше.
+    skip_s3_checksum            = true # Необходимая опция при описании бэкенда для Terraform версии 1.6.3 и старше.
+
+  }
+  
 }
 
 provider "yandex" {

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -19,6 +19,9 @@ terraform {
     skip_requesting_account_id  = true # Необходимая опция Terraform для версии 1.6.1 и старше.
     skip_s3_checksum            = true # Необходимая опция при описании бэкенда для Terraform версии 1.6.3 и старше.
 
+    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1gcd1nmr4tl1hd9duc8/etncm7ju0cs8m6aobpkr"
+    dynamodb_table = "tfstate-123"
+
   }
   
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = "0.133.0"
     }
   }
   required_version = "~>1.8.4"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -77,6 +77,7 @@ variable "each_vm" {
     }
 }
 
+/*
 variable "each_subnet" {
   type = map(object({
     name = string
@@ -95,4 +96,10 @@ variable "each_subnet" {
       cidr = ["10.0.2.0/24"]
     }
   }
+}
+*/
+
+variable "tag" {
+  type = string
+  default = "0.0.1"
 }


### PR DESCRIPTION
3 issue(s) found:

Warning: [Fixable] local.ssh_public_key is declared but not used (terraform_unused_declarations)

  on locals.tf line 3:
   3:     ssh_public_key = local.ssh_pub_key

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 24:
  24:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 45:
  45:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md



Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: marketing-vm
	File: /main.tf:23-43

		23 | module "marketing-vm" {
		24 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		25 |   tag = var.tag
		26 |   env_name       = var.each_vm.marketing.name
		27 |   network_id     = module.vpc.vpc_network_id
		28 |   subnet_zones   = [var.default_zone]
		29 |   subnet_ids     = module.vpc.vpc_network_subnets_id[*]
		30 |   instance_name  = var.each_vm.marketing.name
		31 |   instance_count = var.each_vm.marketing.count
		32 |   image_family   = var.each_vm.marketing.image
		33 |   public_ip      = var.each_vm.marketing.nat
		34 | 
		35 |   labels = { 
		36 |     owner= var.each_vm.marketing.owner,
		37 |     project = var.each_vm.marketing.name
		38 |      }
		39 | 
		40 |   metadata = {
		41 |     user-data          = local.cloudinit
		42 |   }
		43 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: marketing-vm
	File: /main.tf:23-43

		23 | module "marketing-vm" {
		24 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		25 |   tag = var.tag
		26 |   env_name       = var.each_vm.marketing.name
		27 |   network_id     = module.vpc.vpc_network_id
		28 |   subnet_zones   = [var.default_zone]
		29 |   subnet_ids     = module.vpc.vpc_network_subnets_id[*]
		30 |   instance_name  = var.each_vm.marketing.name
		31 |   instance_count = var.each_vm.marketing.count
		32 |   image_family   = var.each_vm.marketing.image
		33 |   public_ip      = var.each_vm.marketing.nat
		34 | 
		35 |   labels = { 
		36 |     owner= var.each_vm.marketing.owner,
		37 |     project = var.each_vm.marketing.name
		38 |      }
		39 | 
		40 |   metadata = {
		41 |     user-data          = local.cloudinit
		42 |   }
		43 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
	FAILED for resource: analytics-vm
	File: /main.tf:45-65

		45 | module "analytics-vm" {
		46 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		47 |   var = var.tag
		48 |   env_name       = var.each_vm.analytics.name
		49 |   network_id     = module.vpc.vpc_network_id
		50 |   subnet_zones   = [var.default_zone]
		51 |   subnet_ids     = module.vpc.vpc_network_subnets_id[*]
		52 |   instance_name  = var.each_vm.analytics.name
		53 |   instance_count = var.each_vm.analytics.count
		54 |   image_family   = var.each_vm.analytics.image
		55 |   public_ip      = var.each_vm.analytics.nat
		56 | 
		57 |   labels = { 
		58 |     owner= var.each_vm.analytics.owner,
		59 |     project = var.each_vm.analytics.name
		60 |      }
		61 | 
		62 |   metadata = {
		63 |     user-data          = local.cloudinit
		64 |   }
		65 | }

Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
	FAILED for resource: analytics-vm
	File: /main.tf:45-65

		45 | module "analytics-vm" {
		46 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
		47 |   var = var.tag
		48 |   env_name       = var.each_vm.analytics.name
		49 |   network_id     = module.vpc.vpc_network_id
		50 |   subnet_zones   = [var.default_zone]
		51 |   subnet_ids     = module.vpc.vpc_network_subnets_id[*]
		52 |   instance_name  = var.each_vm.analytics.name
		53 |   instance_count = var.each_vm.analytics.count
		54 |   image_family   = var.each_vm.analytics.image
		55 |   public_ip      = var.each_vm.analytics.nat
		56 | 
		57 |   labels = { 
		58 |     owner= var.each_vm.analytics.owner,
		59 |     project = var.each_vm.analytics.name
		60 |      }
		61 | 
		62 |   metadata = {
		63 |     user-data          = local.cloudinit
		64 |   }
		65 | }

